### PR TITLE
fix: refine sandbox error handling and update docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -123,7 +123,7 @@ MAX_ABS_DIFF_THRESHOLD=0.1
 #   cd miner && docker build -f Dockerfile.inference -t quasar-miner-gpu:latest .
 #
 # Without this image, all performance tests will fail with "pull access denied".
-VALIDATOR_SANDBOX_IMAGE=quasar-miner-gpu:latest
+# VALIDATOR_SANDBOX_IMAGE=quasar-miner-gpu:latest
 
 # Docker Hub username for pushing miner inference images.
 DOCKER_USERNAME=your_dockerhub_username

--- a/README.md
+++ b/README.md
@@ -110,76 +110,61 @@ python -m neurons.miner \
 
 #### BYOC Mode (Bring Your Own Code)
 
-If you already have an optimized kernel implementation, you can use **BYOC mode** to feed it directly to the miner instead of relying on the LLM to generate one from scratch. This is useful when:
+Two BYOC modes are available:
 
-- You have a hand-optimized CUDA kernel
-- You want to use an existing optimized implementation as a reference
-- You want to improve upon an existing optimization
-
-**Usage**:
-
-1. **Set the BYOC file path** in `.env`:
-   ```bash
-   BYOC_FILE_PATH=./path/to/your/optimized/chunk.py
-   ./START_MINER.sh
-   ```
-
-2. **Or export it before running** the startup script:
-   ```bash
-   export BYOC_FILE_PATH=./path/to/your/optimized/chunk.py
-   ./START_MINER.sh
-   ```
-
-3. **Or use command line arguments directly** (bypassing the startup script):
-   ```bash
-   python -m neurons.miner \
-     --wallet.name "$WALLET_MINER_NAME" \
-     --wallet.hotkey "$WALLET_HOTKEY" \
-     --subtensor.network "$SUBTENSOR_NETWORK" \
-     --netuid "$NETUID" \
-     --byoc-file ./path/to/your/optimized/chunk.py
-   ```
-
-**How it works**:
-
-- The miner will use your provided code as an **expert reference** during code generation
-- The LLM will adapt your code to match the repository structure and requirements
-- Your code's implementation approach will guide the optimization process
-- The miner will still ensure all required imports are included and the code matches the expected signatures
-
-**Tips**:
-
-- Start with a smaller target sequence length first (e.g., `TARGET_SEQUENCE_LENGTH=100000`) - 100k is easier to optimize for
-- Make sure your BYOC file includes all required imports (see [Required Imports](#required-imports-critical) below)
-- The file should be a valid Python file that can be imported and tested
-
-**Example**:
+**BYOC Reference** — LLM uses your code as a reference to guide optimization:
 
 ```bash
-# Using environment variable
-export BYOC_FILE_PATH=./my_optimized_kernels/chunk.py
-export TARGET_SEQUENCE_LENGTH=100000
-./START_MINER.sh
+BYOC_FILE_PATH=./my_chunk.py ./START_MINER.sh
+```
 
-# Or using command line argument
+**BYOC Direct** — Skip the LLM entirely, submit your code directly (no GPU needed for code gen):
+
+```bash
+# Single file
+BYOC_DIRECT=true BYOC_FILE_PATH=./my_chunk.py ./START_MINER.sh
+
+# Directory with multiple target files
+BYOC_DIRECT=true BYOC_DIR=./my_kernels/ ./START_MINER.sh
+```
+
+Or via CLI:
+
+```bash
 python -m neurons.miner \
   --wallet.name "$WALLET_MINER_NAME" \
   --wallet.hotkey "$WALLET_HOTKEY" \
   --subtensor.network "$SUBTENSOR_NETWORK" \
   --netuid "$NETUID" \
-  --byoc-file ./my_optimized_kernels/chunk.py \
-  --target-seq-len 100000
+  --byoc-direct --byoc-file ./my_chunk.py
 ```
+
+BYOC Direct will: copy your files into the fork, validate imports, run benchmarks, commit+push to GitHub, and submit to the Validator API.
+
+**Tips**:
+
+- Make sure your code includes all [required imports](#required-imports-critical) or the validator will reject with score 0.0
+- Use absolute paths for `BYOC_FILE_PATH` / `BYOC_DIR`
+- Target files: `chunk.py`, `fused_recurrent.py`, `gate.py`, `forward_substitution.py`, `chunk_intra_token_parallel.py`, `__init__.py`
 
 ### Validator Neuron
 
-Location: `neurons/validator.py`  
+Location: `neurons/validator.py`
 Role: Bittensor neuron that:
 
 - Polls the Validator API for new submissions
 - Validates miner code, imports, and kernel behavior
-- Runs benchmark tasks and computes rewards
+- Runs benchmark tasks inside a **sandboxed Docker container**
 - Verifies miner outputs using **logit verification** against a reference model
+
+**Prerequisites** (before running the validator):
+
+```bash
+# REQUIRED: Build the sandbox image for miner code benchmarking
+cd miner && docker build -f Dockerfile.inference -t quasar-miner-gpu:latest .
+```
+
+Without this image, all performance tests will fail with `pull access denied` and miners will not be scored.
 
 Local run (using `.env`):
 
@@ -193,6 +178,7 @@ This configures:
 - `SUBTENSOR_NETWORK`
 - `WALLET_VALIDATOR_NAME`
 - `WALLET_HOTKEY`
+- `VALIDATOR_SANDBOX_IMAGE` (default: `quasar-miner-gpu:latest`)
 - Inference verification parameters (`ENABLE_LOGIT_VERIFICATION`, `REFERENCE_MODEL`, thresholds)
 - Commit–reveal timings (`BLOCKS_UNTIL_REVEAL`, `BLOCK_TIME_SECONDS`)
 
@@ -417,9 +403,12 @@ Defined in `.env`:
 | `MAX_ABS_DIFF_THRESHOLD`| `0.1`                                         | Validator neuron        |
 | `BLOCKS_UNTIL_REVEAL`   | `100`                                         | Commit–reveal           |
 | `BLOCK_TIME_SECONDS`    | `12`                                          | Commit–reveal           |
-| `DOCKER_USERNAME`       | `dokerhub_username`                                 | Bazel / oci_push        |
-| `BYOC_FILE_PATH`        | `./path/to/optimized/chunk.py`                     | Miner (BYOC mode)       |
-| `REPO_PATH`             | `./path/to/local/repo`                             | Miner (BYOC mode)       |
+| `DOCKER_USERNAME`       | `dockerhub_username`                                | Bazel / oci_push        |
+| `VALIDATOR_SANDBOX_IMAGE`| `quasar-miner-gpu:latest`                          | Validator (benchmarking) |
+| `BYOC_DIRECT`           | `true` / `false`                                    | Miner (BYOC direct)     |
+| `BYOC_FILE_PATH`        | `/path/to/optimized/chunk.py`                       | Miner (BYOC mode)       |
+| `BYOC_DIR`              | `/path/to/optimized/kernels/`                       | Miner (BYOC direct)     |
+| `REPO_PATH`             | `./path/to/local/repo`                              | Miner (BYOC mode)       |
 
 ---
 

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -553,15 +553,18 @@ if __name__ == "__main__":
                 result = container.wait(timeout=self.SANDBOX_TIMEOUT)
                 output = container.logs().decode(errors="replace")
             except Exception as e:
-                err_str = str(e)
+                err_str = str(e).lower()
                 print(f"[VALIDATOR] Sandbox container error: {e}")
-                # Image pull failures and Docker errors are infra issues,
-                # not miner code faults — mark for retry.
-                if "pull access denied" in err_str or "not found" in err_str.lower() or "404" in err_str:
-                    print(f"[VALIDATOR] Sandbox image '{self.SANDBOX_IMAGE}' not available. "
-                          f"Build it with: cd miner && docker build -f Dockerfile.inference -t {self.SANDBOX_IMAGE} .")
+                # Image pull / not-found errors are infra issues — mark for retry
+                if "pull access denied" in err_str or "not found" in err_str or "404" in err_str:
+                    print(
+                        f"[VALIDATOR] Sandbox image '{self.SANDBOX_IMAGE}' not available. "
+                        f"Build it with: cd miner && docker build -f Dockerfile.inference "
+                        f"-t {self.SANDBOX_IMAGE} ."
+                    )
                     return {"tokens_per_sec": 0.0, "vram_mb": 0.0, "infra_failure": True}
-                return {"tokens_per_sec": 0.0, "vram_mb": 0.0, "infra_failure": True}
+                # Other container errors (OOM, timeout, etc.) are miner faults
+                return {"tokens_per_sec": 0.0, "vram_mb": 0.0}
             finally:
                 if container is not None:
                     try:
@@ -576,8 +579,8 @@ if __name__ == "__main__":
             return self._parse_test_output(output)
 
         except Exception as e:
-            print(f"[VALIDATOR] Test failed: {e}")
-            return {"tokens_per_sec": 0.0, "vram_mb": 0.0}
+            print(f"[VALIDATOR] Test setup failed: {e}")
+            return {"tokens_per_sec": 0.0, "vram_mb": 0.0, "infra_failure": True}
         finally:
             if os.path.exists(temp_test_script):
                 os.remove(temp_test_script)


### PR DESCRIPTION
## Summary
- Refine sandbox container error handling from PR #6
- Update README with validator sandbox prereqs and BYOC Direct docs

## Changes

### Validator (`neurons/validator.py`)
- Image pull errors (`pull access denied`, `404`, `not found`) → `infra_failure: True` (retry)
- Other container errors (OOM, timeout) → miner fault (score 0, no retry)
- Outer test setup failures → `infra_failure: True`

### `.env.example`
- Comment out `VALIDATOR_SANDBOX_IMAGE` (code already defaults to `quasar-miner-gpu:latest`)

### `README.md`
- Add sandbox image build prerequisite for validators
- Add `VALIDATOR_SANDBOX_IMAGE` to validator config list
- Replace old BYOC section with BYOC Reference + BYOC Direct docs
- Add `VALIDATOR_SANDBOX_IMAGE`, `BYOC_DIRECT`, `BYOC_DIR` to env vars table
- Fix `dokerhub_username` typo

## Test plan
- [ ] Validator without sandbox image: submissions stay pending (infra_failure)
- [ ] Container OOM/timeout: scored 0 (not retried)
- [ ] Validator with sandbox image: benchmarks run normally