### PR TITLE
fix: add GPU infra error detection and sandbox debug logging

### DIFF
--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -549,8 +549,12 @@ if __name__ == "__main__":
             except Exception as e:
                 err_str = str(e).lower()
                 print(f"[VALIDATOR] Sandbox container error: {e}")
-                # Image pull / not-found errors are infra issues — mark for retry
-                if "pull access denied" in err_str or "not found" in err_str or "404" in err_str:
+                # Infra errors — mark for retry (not the miner's fault)
+                if ("pull access denied" in err_str
+                        or "not found" in err_str
+                        or "404" in err_str
+                        or "gpu vendor" in err_str
+                        or "nvidia" in err_str):
                     print(
                         f"[VALIDATOR] Sandbox image '{self.SANDBOX_IMAGE}' not available. "
                         f"Build it with: cd miner && docker build -f Dockerfile.inference "

--- a/validator/Dockerfile.sandbox
+++ b/validator/Dockerfile.sandbox
@@ -9,10 +9,16 @@ FROM nvidia/cuda:12.4.1-devel-ubuntu22.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y --no-install-recommends \
-        python3 python3-pip python3-dev git \
-    && rm -rf /var/lib/apt/lists/*
+        software-properties-common \
+    && add-apt-repository ppa:deadsnakes/ppa \
+    && apt-get update && apt-get install -y --no-install-recommends \
+        python3.11 python3.11-dev python3.11-venv git \
+    && rm -rf /var/lib/apt/lists/* \
+    && python3.11 -m ensurepip --upgrade \
+    && ln -sf /usr/bin/python3.11 /usr/bin/python3 \
+    && ln -sf /usr/bin/python3.11 /usr/bin/python
 
-RUN pip3 install --no-cache-dir \
+RUN python3 -m pip install --no-cache-dir \
     torch>=2.0.0 \
     triton>=2.1.0 \
     flash-linear-attention \

--- a/validator/Dockerfile.sandbox
+++ b/validator/Dockerfile.sandbox
@@ -5,11 +5,11 @@
 # Build:
 #   docker build -t quasar-sandbox:latest -f validator/Dockerfile.sandbox .
 #
-FROM nvidia/cuda:12.1.0-runtime-ubuntu22.04
+FROM nvidia/cuda:12.4.1-devel-ubuntu22.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y --no-install-recommends \
-        python3 python3-pip git \
+        python3 python3-pip python3-dev git \
     && rm -rf /var/lib/apt/lists/*
 
 RUN pip3 install --no-cache-dir \


### PR DESCRIPTION
## Summary
- Detect GPU vendor / NVIDIA errors as `infra_failure` (not miner fault) so submissions stay pending for retry
- Log sandbox container output when test results can't be parsed, for easier debugging of sandbox failures

## Test plan
- [ ] Trigger sandbox run without NVIDIA Container Toolkit — should mark as `infra_failure`
- [ ] Trigger sandbox run with broken miner code — should log the error output