### PR TITLE
fix: sandbox image CUDA PyTorch and missing deps

### DIFF
--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -557,8 +557,8 @@ if __name__ == "__main__":
                         or "nvidia" in err_str):
                     print(
                         f"[VALIDATOR] Sandbox image '{self.SANDBOX_IMAGE}' not available. "
-                        f"Build it with: cd miner && docker build -f Dockerfile.inference "
-                        f"-t {self.SANDBOX_IMAGE} ."
+                        f"Build it with: docker build -t {self.SANDBOX_IMAGE} "
+                        f"-f validator/Dockerfile.sandbox ."
                     )
                     return {"tokens_per_sec": 0.0, "vram_mb": 0.0, "infra_failure": True}
                 # Other container errors (OOM, timeout, etc.) are miner faults

--- a/validator/Dockerfile.sandbox
+++ b/validator/Dockerfile.sandbox
@@ -1,5 +1,5 @@
 # Sandbox image for validator performance testing.
-# Contains Python, PyTorch, Triton, and flash-linear-attention (fla).
+# Contains Python, PyTorch (CUDA), Triton, and flash-linear-attention (fla).
 # Miner code is mounted read-only at /workspace at runtime.
 #
 # Build:
@@ -18,9 +18,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && ln -sf /usr/bin/python3.11 /usr/bin/python3 \
     && ln -sf /usr/bin/python3.11 /usr/bin/python
 
+# Install PyTorch with CUDA support (default pip installs CPU-only)
 RUN python3 -m pip install --no-cache-dir \
-    torch>=2.0.0 \
+    torch --index-url https://download.pytorch.org/whl/cu124
+
+RUN python3 -m pip install --no-cache-dir \
     triton>=2.1.0 \
+    causal-conv1d>=1.4.0 \
     flash-linear-attention \
     numpy>=1.24.0
 


### PR DESCRIPTION
## Summary
- Install PyTorch with CUDA support via `--index-url cu124` (default pip installs CPU-only, causing sandbox benchmarks to fail)
- Add `causal-conv1d>=1.4.0` dependency required by `fla` convolution ops
- Fix infra error message to reference `validator/Dockerfile.sandbox`

## Test plan
- [ ] Rebuild sandbox: `docker build -t quasar-sandbox:latest -f validator/Dockerfile.sandbox .`
- [ ] Verify CUDA: `docker run --rm --gpus all quasar-sandbox:latest python3 -c "import torch; print(torch.cuda.is_available())"`
- [ ] Run validator and confirm sandbox benchmarks produce RESULT output