### PR TITLE
fix: handle 429 rate limit in submission retries

### DIFF
--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -4,6 +4,7 @@
 import os
 import time
 import typing
+import re
 import requests
 import hashlib
 import subprocess
@@ -806,9 +807,6 @@ class Miner(BaseMinerNeuron):
                 "network": network,
             }
             
-            headers = self._get_auth_headers()
-            headers["Content-Type"] = "application/json"
-            
             bt.logging.info(f"Submitting to validator: {performance:.2f} tokens/sec")
             print(f"[API] Submitting to validator: {performance:.2f} tokens/sec", flush=True)
 
@@ -834,6 +832,7 @@ class Miner(BaseMinerNeuron):
                     print(f"[API] Response status: {response.status_code}", flush=True)
                     print(f"[API] Response text: {response.text[:500]}", flush=True)
 
+                    # Validation errors won't fix on retry — fail immediately
                     if response.status_code == 422:
                         detail = response.json().get("detail", response.text[:500])
                         raise ValueError(f"Validation error from /submit_kernel: {detail}")
@@ -842,8 +841,7 @@ class Miner(BaseMinerNeuron):
                     if response.status_code == 429:
                         try:
                             detail = response.json().get("detail", "")
-                            import re as _re
-                            match = _re.search(r"wait (\d+) seconds", detail)
+                            match = re.search(r"wait (\d+) seconds", detail)
                             wait = int(match.group(1)) + 5 if match else 30
                         except Exception:
                             wait = 30

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -815,6 +815,11 @@ class Miner(BaseMinerNeuron):
             last_err: Optional[Exception] = None
             for attempt in range(3):
                 try:
+                    # Regenerate auth headers each attempt so the
+                    # timestamp/signature stays fresh.
+                    headers = self._get_auth_headers()
+                    headers["Content-Type"] = "application/json"
+
                     response = self._api_request(
                         "POST",
                         "/submit_kernel",
@@ -833,6 +838,19 @@ class Miner(BaseMinerNeuron):
                         detail = response.json().get("detail", response.text[:500])
                         raise ValueError(f"Validation error from /submit_kernel: {detail}")
 
+                    # Rate limited — parse wait time and sleep
+                    if response.status_code == 429:
+                        try:
+                            detail = response.json().get("detail", "")
+                            import re as _re
+                            match = _re.search(r"wait (\d+) seconds", detail)
+                            wait = int(match.group(1)) + 5 if match else 30
+                        except Exception:
+                            wait = 30
+                        print(f"[API] Rate limited, waiting {wait}s before retry...", flush=True)
+                        time.sleep(wait)
+                        continue
+
                     response.raise_for_status()
                     result = response.json()
                     bt.logging.info(f"Submission successful: {result.get('submission_id')}")
@@ -842,7 +860,7 @@ class Miner(BaseMinerNeuron):
                     last_err = e
                     bt.logging.warning(f"Submission attempt {attempt + 1}/3 failed: {e}")
                     print(f"[API] Submission attempt {attempt + 1}/3 failed: {e}", flush=True)
-                    time.sleep(2 * (attempt + 1))
+                    time.sleep(10)
 
             if last_err is not None:
                 raise last_err


### PR DESCRIPTION
## Summary
- Handle 429 rate limit responses by parsing the wait time and sleeping accordingly instead of retrying immediately
- Regenerate auth headers on each retry attempt to prevent stale timestamp/signature errors
- Increase default retry backoff from 2-4s to 10s

## Test plan
- [ ] Submit miner kernel, verify no rapid-fire 429 retries
- [ ] Verify successful submission after rate limit wait