### PR TITLE
fix: benchmark error reporting, test import stub, and dead code

### DIFF
--- a/miner/Dockerfile.inference
+++ b/miner/Dockerfile.inference
@@ -26,12 +26,16 @@ ENV PYTHONDONTWRITEBYTECODE=1
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Install Python and dependencies
-RUN apt-get update && apt-get install -y \
+# Include curl for Docker HEALTHCHECK and clean apt caches/lists completely
+# so nothing triggers apt at runtime (validator runs with cap_drop=ALL).
+RUN apt-get update && apt-get install -y --no-install-recommends \
     python3 \
     python3-pip \
     python3-venv \
     git \
-    && rm -rf /var/lib/apt/lists/*
+    curl \
+    && rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*.deb \
+       /var/cache/apt/archives/partial/*.deb /var/log/apt/*
 
 # Create working directory
 WORKDIR /app
@@ -53,9 +57,9 @@ ENV PORT=8000
 # Expose the inference port
 EXPOSE 8000
 
-# Health check
+# Health check — use python3 instead of curl to avoid needing extra capabilities
 HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
-    CMD curl -f http://localhost:8000/health || exit 1
+    CMD python3 -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')" || exit 1
 
 # Run the inference server
 CMD ["python3", "inference_server.py"]

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -1720,6 +1720,7 @@ class Miner(BaseMinerNeuron):
                     # Set environment variable for memory management
                     env = os.environ.copy()
                     env["PYTORCH_CUDA_ALLOC_CONF"] = "expandable_segments:True"
+                    env["PYTHONUNBUFFERED"] = "1"
 
                     result = subprocess.run(
                         [sys.executable, test_script_path],
@@ -1730,8 +1731,16 @@ class Miner(BaseMinerNeuron):
                     )
 
                     if result.returncode != 0:
+                        exit_reason = f"exit code {result.returncode}"
+                        if result.returncode < 0:
+                            import signal
+                            try:
+                                sig_name = signal.Signals(-result.returncode).name
+                                exit_reason = f"signal {sig_name} ({result.returncode})"
+                            except (ValueError, AttributeError):
+                                exit_reason = f"signal {-result.returncode}"
                         print(
-                            f"[MINER] Tests Failed:\n{result.stderr}",
+                            f"[MINER] Tests Failed ({exit_reason}):\n{result.stderr}",
                             flush=True,
                         )
 

--- a/tests/test_quasar_mining.py
+++ b/tests/test_quasar_mining.py
@@ -11,7 +11,64 @@ os.environ["TRITON_PRINT_DEBUG"] = "1"
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-from fla.layers.quasar import QuasarAttention
+import sys
+import types
+
+def _import_quasar_attention():
+    """Import only QuasarAttention, bypassing broken eager imports in fla.
+
+    The upstream fla package eagerly imports ALL layers and ALL ops in its
+    __init__.py files (fla/__init__.py, fla/layers/__init__.py, fla/ops/__init__.py).
+    Many of these fail with triton incompatibilities or missing symbols.
+
+    Solution: pre-register fla, fla.layers, and fla.ops as minimal stub packages
+    (with correct __path__) so their __init__.py files are never executed.
+    Submodules like fla.layers.quasar, fla.ops.quasar, fla.ops.utils are still
+    found via __path__ and imported normally.
+    """
+    # First try normal import (works when fla is fully compatible)
+    try:
+        from fla.layers.quasar import QuasarAttention
+        return QuasarAttention
+    except (ImportError, AttributeError, AssertionError, RuntimeError):
+        pass
+
+    # Clean up failed partial imports
+    for key in list(sys.modules):
+        if key == "fla" or key.startswith("fla."):
+            del sys.modules[key]
+
+    # Find the fla package root on disk
+    import importlib.util
+    fla_spec = importlib.util.find_spec("fla")
+    if fla_spec is None:
+        raise ImportError("Cannot find fla package on sys.path")
+    fla_root = os.path.dirname(fla_spec.origin)
+
+    # Pre-register stub packages so their __init__.py files are NOT executed.
+    # Each stub has __path__ pointing to the real directory so submodules
+    # (fla.layers.quasar, fla.ops.quasar, fla.ops.utils, etc.) resolve normally.
+    stub_pkgs = {
+        "fla": fla_root,
+        "fla.layers": os.path.join(fla_root, "layers"),
+        "fla.ops": os.path.join(fla_root, "ops"),
+    }
+    for pkg_name, pkg_dir in stub_pkgs.items():
+        stub = types.ModuleType(pkg_name)
+        stub.__path__ = [pkg_dir]
+        stub.__file__ = os.path.join(pkg_dir, "__init__.py")
+        stub.__package__ = pkg_name
+        sys.modules[pkg_name] = stub
+
+    # Wire parent-child attributes
+    sys.modules["fla"].layers = sys.modules["fla.layers"]
+    sys.modules["fla"].ops = sys.modules["fla.ops"]
+
+    # Now import QuasarAttention — only its real dependencies are loaded
+    from fla.layers.quasar import QuasarAttention
+    return QuasarAttention
+
+QuasarAttention = _import_quasar_attention()
 
 def test_quasar_basic():
     print("Testing QuasarAttention basic functionality...")
@@ -115,22 +172,19 @@ def test_quasar_basic():
             
             with torch.autocast(device_type="cuda", dtype=torch.bfloat16) if device.type == "cuda" else torch.no_grad():
                 output, _, _ = quasar(x)
-            
-            # Success - break out of retry loop
-            break
-        
+
             print(f"Output shape: {output.shape}")
             print("QuasarAttention basic test PASSED!")
-            
+
             # Cleanup after test
             del output, x, quasar
             if torch.cuda.is_available():
                 torch.cuda.empty_cache()
                 import gc
                 gc.collect()
-            
+
             return True
-            
+
         except torch.cuda.OutOfMemoryError as e:
             retry_count += 1
             print(f"CUDA OOM Error (attempt {retry_count}/{max_retries}): {e}")


### PR DESCRIPTION
## Summary
- **test**: Add stub-package import for `QuasarAttention` to handle broken upstream fla eager imports with triton 3.1.0 incompatibilities (e.g., `'NoneType' object has no attribute 'start'` from `@triton.jit`)
- **test**: Fix unreachable code after `break` in `test_quasar_basic()` — cleanup, PASS message, and `return True` were never executing (dead code since lines 179-189 came after `break` on line 177)
- **miner**: Add `PYTHONUNBUFFERED=1` to benchmark subprocess so stdout is not lost on segfault; print signal name on non-zero exit (e.g., `SIGSEGV` instead of silent failure)
- **docker**: Add `curl` to inference Dockerfile, use `python3` healthcheck to avoid capability issues under `cap_drop=ALL` security hardening

## Test plan
- [ ] Run `test_quasar_mining.py` on a machine with triton 3.1.0 — import should succeed via stub fallback
- [ ] Run miner benchmark that segfaults — should now see `[MINER] Tests Failed (signal SIGSEGV (-11)):` with captured stdout
- [ ] Verify `test_quasar_basic()` now prints "PASSED!" and returns True
- [ ] Build inference Docker image and verify healthcheck passes under `cap_drop=ALL`